### PR TITLE
2 bugfixes and several new features for createclass, createcontent and createrole handlers

### DIFF
--- a/classes/ezxmlinstallerhandler.php
+++ b/classes/ezxmlinstallerhandler.php
@@ -147,6 +147,43 @@ class eZXMLInstallerHandler
         return $string;
     }
 
+    /**
+     * Browses node to replace any string references in subnodes or attributes
+     *
+     * @since 0.1.5
+     * @param DOMNode 	$node	node to inspect
+     * @return DOMNode	Node with replaced string references
+     */
+    function parseAndReplaceNodeStringReferences( DOMNode $node )
+    {
+        $attrs = $node->attributes;
+        foreach ( $attrs as $attr )
+        {
+            $node->setAttribute( $attr->name, $this->getReferenceID( $attr->value ) );
+        }
+
+        $children = $node->childNodes;
+        foreach ( $children as $child )
+        {
+            switch ( $child->nodeType )
+            {
+                case XML_TEXT_NODE:
+                    $child->textContent = $this->parseAndReplaceStringReferences( $child->textContent );
+                    break;
+
+                case XML_CDATA_SECTION_NODE:
+                    $child->replaceData( $this->parseAndReplaceStringReferences( $child->data ) );
+                    break;
+
+                case XML_ELEMENT_NODE:
+                    $child = $this->parseAndReplaceNodeStringReferences($child);
+                    break;
+            }
+        }
+
+        return $node;
+    }
+
     function settings( )
     {
         return $this->Settings;

--- a/classes/ezxmlinstallerhandler.php
+++ b/classes/ezxmlinstallerhandler.php
@@ -150,7 +150,7 @@ class eZXMLInstallerHandler
     /**
      * Browses node to replace any string references in subnodes or attributes
      *
-     * @since 0.1.5
+     * @since 1.2.1
      * @param DOMNode 	$node	node to inspect
      * @return DOMNode	Node with replaced string references
      */

--- a/classes/ezxmlinstallerhandler.php
+++ b/classes/ezxmlinstallerhandler.php
@@ -148,7 +148,7 @@ class eZXMLInstallerHandler
     }
 
     /**
-     * Browses node to replace any string references in subnodes or attributes
+     * Browses $node to replace any string references in subnodes or attributes
      *
      * @since 1.2.1
      * @param DOMNode 	$node	node to inspect

--- a/data/createcontent_objectrelations.xml
+++ b/data/createcontent_objectrelations.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eZXMLImporter xmlns="http://ez.no/URI/xmlinstaller/0.1.5">
+	<CreateContent>
+		<ContentObject contentClass="article">
+			<Attributes>
+			 <title>Linked Article</title>
+			</Attributes>
+			<SetReference attribute="object_id" value="linked_article"></SetReference>
+		</ContentObject>
+        <ContentObject contentClass="article">
+            <Attributes>
+             <title>Article linking to previous one and Home</title>
+            </Attributes>
+            <Relation target="internal:linked_article" />
+            <Relation target="1" />
+        </ContentObject>
+	</CreateContent>
+</eZXMLImporter>

--- a/eventtypes/event/ezxmlpublisher/ezxmlpublishertype.php
+++ b/eventtypes/event/ezxmlpublisher/ezxmlpublishertype.php
@@ -29,7 +29,15 @@ class eZXMLPublisherType extends eZWorkflowEventType
 {
     public function eZXMLPublisherType()
     {
-        $this->eZWorkflowEventType( 'ezxmlpublisher', ezpI18n::tr( 'extension/ezxmkinstaller', 'XML Publisher' ) );
+        if( class_exists( 'ezpI18n' ) )
+        {
+            $this->eZWorkflowEventType( 'ezxmlpublisher', ezpI18n::tr( 'extension/ezxmkinstaller', 'XML Publisher' ) );
+        }
+        else
+        {
+            include_once( 'kernel/common/i18n.php' );
+            $this->eZWorkflowEventType( 'ezxmlpublisher', ezi18n( 'extension/ezxmkinstaller', 'XML Publisher' ) );
+        }
         $this->setTriggerTypes( array( 'content' => array( 'publish' => array( 'after' ) ) ) );
     }
 

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -69,9 +69,8 @@ class eZCreateClass extends eZXMLInstallerHandler
 
             $nameList = array();
             $nameListObject = $class->getElementsByTagName( 'Names' )->item( 0 );
-            if ( $nameListObject->parentNode === $class && $nameListObject->hasAttributes() )
+            if ( $nameListObject && $nameListObject->parentNode === $class && $nameListObject->hasAttributes() )
             {
-                print 'found names';
                 $attributes = $nameListObject->attributes;
                 if ( !is_null($attributes) )
                 {

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -67,30 +67,33 @@ class eZCreateClass extends eZXMLInstallerHandler
             $classGroupsNode        = $class->getElementsByTagName( 'Groups' )->item( 0 );
             $classAttributesNode    = $class->getElementsByTagName( 'Attributes' )->item( 0 );
 
+            $nameList = array();
             $nameListObject = $class->getElementsByTagName( 'Names' )->item( 0 );
-            if ( $nameListObject->hasAttributes() )
+            if ( $nameListObject->parentNode === $class && $nameListObject->hasAttributes() )
             {
-                if ( $nameListObject->hasAttributes())
+                print 'found names';
+                $attributes = $nameListObject->attributes;
+                if ( !is_null($attributes) )
                 {
-                    $attributes = $nameListObject->attributes;
-                    if ( !is_null($attributes) )
+                    foreach ( $attributes as $index=>$attr )
                     {
-                        $nameList = array();
-                        foreach ( $attributes as $index=>$attr )
+                        if ( in_array( $attr->name, $availableLanguageList ) )
                         {
-                            if ( in_array( $attr->name, $availableLanguageList ) )
-                            {
-                                $nameList[$attr->name] = $attr->value;
-                            }
+                            $nameList[$attr->name] = $attr->value;
                         }
                     }
                 }
             }
 
-
-            $classNameList = new eZContentClassNameList( serialize($nameList) );
-            $classNameList->validate( );
-
+            if( !empty( $nameList ) )
+            {
+                $classNameList = new eZContentClassNameList( serialize($nameList) );
+                $classNameList->validate( );
+            }
+            else
+            {
+                $classNameList = null;
+            }
 
             $dateTime = time();
             $classCreated = $dateTime;
@@ -302,7 +305,7 @@ class eZCreateClass extends eZXMLInstallerHandler
                 }
             }
 
-            $classNameList->store( $class );
+            if( $classNameList ) $classNameList->store( $class );
 
 
             // add class to a class group

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -236,7 +236,7 @@ class eZCreateClass extends eZXMLInstallerHandler
 
                 $params = array();
                 $params['identifier']               = $attributeIdentifier;
-                $params['serialized_name_list']     = $classAttributeNameList->serializeNames();
+                $params['name_list']     = $classAttributeNameList;
                 $params['data_type_string']         = $attributeDatatype;
                 $params['default_value']            = '';
                 $params['can_translate']            = $attributeIsTranslatable;
@@ -392,7 +392,7 @@ class eZCreateClass extends eZXMLInstallerHandler
         $classID = $class->attribute( 'id' );
 
         $classAttributeIdentifier = $params['identifier'];
-        $classAttributeName = $params['serialized_name_list'];
+        $classAttributeNameList = $params['name_list'];
 
         $datatype = $params['data_type_string'];
         $defaultValue = isset( $params['default_value'] ) ? $params['default_value'] : false;
@@ -402,7 +402,7 @@ class eZCreateClass extends eZXMLInstallerHandler
         $attrContent  = isset( $params['content'] )       ? $params['content'] : false;
 
         $attrCreateInfo = array( 'identifier' => $classAttributeIdentifier,
-                                    'serialized_name_list' => $classAttributeName,
+                                    'serialized_name_list' => $classAttributeNameList->serializeNames(),
                                     'can_translate' => $canTranslate,
                                     'is_required' => $isRequired,
                                     'is_searchable' => $isSearchable );
@@ -465,7 +465,7 @@ class eZCreateClass extends eZXMLInstallerHandler
         $classID = $class->attribute( 'id' );
 
         $classAttributeIdentifier = $params['identifier'];
-        $classAttributeName = $params['serialized_name_list'];
+        $classAttributeNameList = $params['name_list'];
 
         $classAttribute = $class->fetchAttributeByIdentifier( $classAttributeIdentifier );
 
@@ -475,9 +475,9 @@ class eZCreateClass extends eZXMLInstallerHandler
             return false;
         }
 
+        $classAttribute->NameList = $classAttributeNameList;
         $classAttribute->setAttribute( 'data_type_string',  $params['data_type_string']  );
         $classAttribute->setAttribute( 'identifier', $classAttributeIdentifier  );
-        $classAttribute->setAttribute( 'serialized_name_list', $classAttributeName  );
         $classAttribute->setAttribute( 'is_required', $params['is_required']  );
         $classAttribute->setAttribute( 'is_searchable', $params['is_searchable']  );
         $classAttribute->setAttribute( 'can_translate', $params['can_translate']  );

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -401,13 +401,15 @@ class eZCreateClass extends eZXMLInstallerHandler
         $canTranslate = isset( $params['can_translate']   ) ? $params['can_translate'] : 0;
         $isRequired   = isset( $params['is_required']   ) ? $params['is_required'] : 0;
         $isSearchable = isset( $params['is_searchable'] ) ? $params['is_searchable'] : 0;
+        $isCollector  = isset( $params['is_information_collector'] ) ? $params['is_information_collector'] : false;
         $attrContent  = isset( $params['content'] )       ? $params['content'] : false;
 
         $attrCreateInfo = array( 'identifier' => $classAttributeIdentifier,
                                     'serialized_name_list' => $classAttributeNameList->serializeNames(),
                                     'can_translate' => $canTranslate,
                                     'is_required' => $isRequired,
-                                    'is_searchable' => $isSearchable );
+                                    'is_searchable' => $isSearchable,
+                                    'is_information_collector' => $isCollector );
         $newAttribute = eZContentClassAttribute::create( $classID, $datatype, $attrCreateInfo  );
 
         $dataType = $newAttribute->dataType();

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -123,9 +123,9 @@ class eZCreateClass extends eZXMLInstallerHandler
                         $class->setAttribute( 'is_container', $classIsContainer );
                         $class->setAttribute( 'url_alias_name', $classURLAliasPattern );
 
-                        $class->set();
+                        //$class->set();
                         $class->store();
-                        /* TODO: Remove all attributes */
+                        $class->removeAttributes();
                     } break;
                     case 'new':
                     {

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -263,13 +263,9 @@ class eZCreateClass extends eZXMLInstallerHandler
 
             if( $this->_adjustAttributesPlacement )
             {
+                //once every attribute has been processed, we may reset placement
                 $this->writeMessage( "\t\tAdjusting attributes placement.", 'notice' );
-                $attributes = $class->fetchAttributes();
-                $class->adjustAttributePlacements( $attributes );
-                foreach( $attributes as $attribute )
-                {
-                    $attribute->store();
-                }
+                $this->_adjustClassAttributesPlacement($class);
             }
 
             if ( count( $updateAttributeList ) )
@@ -500,7 +496,22 @@ class eZCreateClass extends eZXMLInstallerHandler
 
     }
 
-
+    /**
+     * Updates placement for each attribute in a class instance
+     *
+     * @since 0.1.5
+     * @param eZContentClass $class class instance to update
+     * @return null
+     */
+    protected function _adjustClassAttributesPlacement(eZContentClass $class)
+    {
+        $attributes = $class->fetchAttributes();
+        $class->adjustAttributePlacements( $attributes );
+        foreach( $attributes as $attribute )
+        {
+            $attribute->store();
+        }
+    }
 }
 
 ?>

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -245,7 +245,7 @@ class eZCreateClass extends eZXMLInstallerHandler
                 $params['content']                  = '';
                 $params['placement']                = $attributePlacement;
                 $params['is_information_collector'] = $attributeIsInformationCollector;
-                $params['datatype-parameter']       = $attributeDatatypeParameterNode;
+                $params['datatype-parameter']       = $this->parseAndReplaceNodeStringReferences( $attributeDatatypeParameterNode );
                 $params['attribute-node']           = $classAttributeNode;
 
                 if ( !array_key_exists( $attributeIdentifier, $classDataMap ) )

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -58,7 +58,7 @@ class eZCreateClass extends eZXMLInstallerHandler
 
             $this->writeMessage( "\tClass '$classIdentifier' will be updated.", 'notice' );
 
-            $classURLAliasPattern   = is_object( $class->getAttribute( 'urlAliasPattern' ) ) ? $class->getAttribute( 'urlAliasPattern' ) : null;
+            $classURLAliasPattern   = $class->getAttribute( 'urlAliasPattern' ) ? $class->getAttribute( 'urlAliasPattern' ) : null;
 
             $classIsContainer       = $class->getAttribute( 'isContainer' );
             if ( $classIsContainer !== false )

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -125,7 +125,6 @@ class eZCreateClass extends eZXMLInstallerHandler
                         $class->setAttribute( 'is_container', $classIsContainer );
                         $class->setAttribute( 'url_alias_name', $classURLAliasPattern );
 
-                        //$class->set();
                         $class->store();
                         $class->removeAttributes();
                     } break;
@@ -238,7 +237,7 @@ class eZCreateClass extends eZXMLInstallerHandler
 
                 $params = array();
                 $params['identifier']               = $attributeIdentifier;
-                $params['name_list']     = $classAttributeNameList;
+                $params['name_list']                = $classAttributeNameList;
                 $params['data_type_string']         = $attributeDatatype;
                 $params['default_value']            = '';
                 $params['can_translate']            = $attributeIsTranslatable;

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -32,7 +32,7 @@ class eZCreateClass extends eZXMLInstallerHandler
      * @since 1.2.1
      * @var boolean
      */
-    private $_adjustAttributesPlacement = false;
+    private $adjustAttributesPlacement = false;
 
     function eZCreateClass( )
     {
@@ -45,7 +45,7 @@ class eZCreateClass extends eZXMLInstallerHandler
         $availableLanguageList = eZContentLanguage::fetchLocaleList();
         foreach ( $classList as $class )
         {
-            $this->_adjustAttributesPlacement = false;
+            $this->adjustAttributesPlacement = false;
 
             $user = eZUser::currentUser();
             $userID = $user->attribute( 'contentobject_id' );
@@ -262,11 +262,11 @@ class eZCreateClass extends eZXMLInstallerHandler
                 }
             }
 
-            if( $this->_adjustAttributesPlacement )
+            if( $this->adjustAttributesPlacement )
             {
                 //once every attribute has been processed, we may reset placement
                 $this->writeMessage( "\t\tAdjusting attributes placement.", 'notice' );
-                $this->_adjustClassAttributesPlacement($class);
+                $this->adjustClassAttributesPlacement($class);
             }
 
             if ( count( $updateAttributeList ) )
@@ -441,7 +441,7 @@ class eZCreateClass extends eZXMLInstallerHandler
         $placement = $params['placement'] ? intval( $params['placement'] ) : count( $attributes );
         $newAttribute->setAttribute( 'placement',  $placement);
 
-        $this->_adjustAttributesPlacement = true;
+        $this->adjustAttributesPlacement = true;
 
         $newAttribute->storeDefined();
         $classAttributeID = $newAttribute->attribute( 'id' );
@@ -474,7 +474,7 @@ class eZCreateClass extends eZXMLInstallerHandler
         if( $params['placement'] )
         {
             $classAttribute->setAttribute( 'placement', $params['placement'] );
-            $this->_adjustAttributesPlacement = true;
+            $this->adjustAttributesPlacement = true;
         }
 
         $dataType = $classAttribute->dataType();
@@ -490,7 +490,7 @@ class eZCreateClass extends eZXMLInstallerHandler
      * @since 1.2.1
      * @param eZContentClass $class class instance to update
      */
-    protected function _adjustClassAttributesPlacement(eZContentClass $class)
+    protected function adjustClassAttributesPlacement(eZContentClass $class)
     {
         $attributes = $class->fetchAttributes();
         $class->adjustAttributePlacements( $attributes );

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -424,21 +424,6 @@ class eZCreateClass extends eZXMLInstallerHandler
         $newAttribute->sync();
 
 
-        // not all datatype can have 'default_value'. do check here.
-        if( $defaultValue !== false  )
-        {
-            switch( $datatype )
-            {
-                case 'ezboolean':
-                {
-                    $newAttribute->setAttribute( 'data_int3', $defaultValue );
-                }
-                break;
-
-                default:
-                    break;
-            }
-        }
 
         if( $attrContent )
             $newAttribute->setContent( $attrContent );

--- a/xmlinstallerhandler/ezcreateclass.php
+++ b/xmlinstallerhandler/ezcreateclass.php
@@ -29,7 +29,7 @@ class eZCreateClass extends eZXMLInstallerHandler
 {
     /**
      * Tells execute algorithm to adjust current class's attributes placement if needed
-     *
+     * @since 1.2.1
      * @var boolean
      */
     private $_adjustAttributesPlacement = false;
@@ -503,9 +503,8 @@ class eZCreateClass extends eZXMLInstallerHandler
     /**
      * Updates placement for each attribute in a class instance
      *
-     * @since 0.1.5
+     * @since 1.2.1
      * @param eZContentClass $class class instance to update
-     * @return null
      */
     protected function _adjustClassAttributesPlacement(eZContentClass $class)
     {

--- a/xmlinstallerhandler/ezcreatecontent.php
+++ b/xmlinstallerhandler/ezcreatecontent.php
@@ -391,6 +391,24 @@ class eZCreateContent extends eZXMLInstallerHandler
                             }
                         } break;
 
+                        case 'ezobjectrelationlist':
+                        {
+                            $relationContent = explode( ',', $attributesContent['content'] );
+                            if ( count( $relationContent ) )
+                            {
+                                $objectIDs = array();
+                                foreach( $relationContent as $relation )
+                                {
+                                    $objectIDs[] = $this->getReferenceID( trim ( $relation ) );
+                                }
+                                $attribute->fromString( implode( '-', $objectIDs ) );
+                            }
+                            else
+                            {
+                                eZDebug::writeWarning( $attributesContent['content'], "No relation declared" );
+                            }
+                        } break;
+
 
                         case 'ezauthor':
                         case 'ezbinaryfile':
@@ -404,15 +422,22 @@ class eZCreateContent extends eZXMLInstallerHandler
                         case 'ezmedia':
                         case 'ezmultioption':
                         case 'ezmultiprice':
-                        case 'ezobjectrelationlist':
                         case 'ezoption':
                         case 'ezpackage':
                         case 'ezproductcategory':
                         case 'ezrangeoption':
                         case 'ezsubtreesubscription':
                         case 'eztime':
+                        default:
                         {
-                            $this->writeMessage( "\tDatatype " . $dataType . " not supported yet.", 'warning' );
+                            try
+                            {
+                                $attribute->fromString($attributesContent['content']);
+                            }
+                            catch ( Exception $e )
+                            {
+                                $this->writeMessage( "\tDatatype " . $dataType . " fromString function rejected value " . $attributesContent['content'], 'warning' );
+                            }
                         } break;
 
                     }

--- a/xmlinstallerhandler/ezcreatecontent.php
+++ b/xmlinstallerhandler/ezcreatecontent.php
@@ -88,6 +88,8 @@ class eZCreateContent extends eZXMLInstallerHandler
             $objectInformation['ownerID'] = $objectNode->getAttribute( 'owner' );
             $objectInformation['creatorID'] = $objectNode->getAttribute( 'creator' );
             $objectInformation['attributes'] = array();
+            $objectInformation['sort_field'] = $objectNode->hasAttribute( 'sort_field' ) ? $objectNode->getAttribute( 'sort_field' ) : 'path';
+            $objectInformation['sort_order'] = $objectNode->hasAttribute( 'sort_order' ) ? $objectNode->getAttribute( 'sort_order' ) : 'asc';
 
             switch( $priorityMode )
             {
@@ -238,11 +240,17 @@ class eZCreateContent extends eZXMLInstallerHandler
         {
             $db->begin();
             $versionNumber  = $contentObjectVersion->attribute( 'version' );
+
+            $sortField = intval( eZContentObjectTreeNode::sortFieldID( $objectInformation['sort_field'] ) );
+            $sortOrder = strtolower( $objectInformation['sort_order'] ) == 'desc' ? eZContentObjectTreeNode::SORT_ORDER_DESC : eZContentObjectTreeNode::SORT_ORDER_ASC;
+
             $nodeAssignment = eZNodeAssignment::create(
                     array(  'contentobject_id'      => $contentObject->attribute( 'id' ),
                             'contentobject_version' => $versionNumber,
                             'parent_node'           => $objectInformation['parentNode'],
-                            'is_main'               => 1
+                            'is_main'               => 1,
+                            'sort_field'			=> $sortField,
+                            'sort_order'			=> $sortOrder,
                             )
             );
             $nodeAssignment->store();

--- a/xmlinstallerhandler/ezcreatecontent.php
+++ b/xmlinstallerhandler/ezcreatecontent.php
@@ -299,13 +299,21 @@ class eZCreateContent extends eZXMLInstallerHandler
                             {
                                 $content = $attributesContent['content'];
                             }
-                            $xml = '<?xml version="1.0" encoding="utf-8"?>'."\n".
-                                    '<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/"'."\n".
-                                    '         xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"'."\n".
-                                    '         xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">'."\n".
-                                    '  <section>'."\n";
-                            $xml .= '    <paragraph>' . $content . "</paragraph>\n";
-                            $xml .= "  </section>\n</section>\n";
+
+                            if( array_key_exists( 'fullxml', $attributesContent ) && $attributesContent['fullxml'] == "true" )
+                            {
+                                $xml = $content;
+                            }
+                            else
+                            {
+                                $xml = '<?xml version="1.0" encoding="utf-8"?>'."\n".
+                                        '<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/"'."\n".
+                                        '         xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"'."\n".
+                                        '         xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">'."\n".
+                                        '  <section>'."\n";
+                                $xml .= '    <paragraph>' . $content . "</paragraph>\n";
+                                $xml .= "  </section>\n</section>\n";
+                            }
 
                             $attribute->setAttribute( 'data_text', $xml );
                         } break;

--- a/xmlinstallerhandler/ezcreatecontent.php
+++ b/xmlinstallerhandler/ezcreatecontent.php
@@ -37,7 +37,7 @@ class eZCreateContent extends eZXMLInstallerHandler
      * - auto :  priorities are automatically incremented
      *
      * Default is none
-     * @since 0.1.5
+     * @since 1.2.1
      */
     const PRIORITY_MODE_NONE = 'none';
     const PRIORITY_MODE_FIXED = 'fixed';
@@ -542,7 +542,7 @@ class eZCreateContent extends eZXMLInstallerHandler
      * Updates node priority
      * @param int $node_id		Node to update
      * @param int $priority		New priority value
-     * @since 0.1.5
+     * @since 1.2.1
      */
     protected function updateNodePriority( $node_id, $priority )
     {

--- a/xmlinstallerhandler/ezcreatecontent.php
+++ b/xmlinstallerhandler/ezcreatecontent.php
@@ -547,9 +547,9 @@ class eZCreateContent extends eZXMLInstallerHandler
     }
 
     /**
-     * Updates node priority
-     * @param int $node_id		Node to update
-     * @param int $priority		New priority value
+     * Updates the priority for node $node_id to $priority
+     * @param int $node_id
+     * @param int $priority
      * @since 1.2.1
      */
     protected function updateNodePriority( $node_id, $priority )

--- a/xmlinstallerhandler/ezcreatecontent.php
+++ b/xmlinstallerhandler/ezcreatecontent.php
@@ -92,6 +92,25 @@ class eZCreateContent extends eZXMLInstallerHandler
                     }
                 }
             }
+
+            $relationNodes = $objectNode->getElementsByTagName( 'Relation' );
+            if( $relationNodes->length )
+            {
+                $objectInformation['relations'] = array();
+                foreach ( $relationNodes as $relationNode )
+                {
+                    $targetRef = $relationNode->getAttribute( 'target' );
+                    if( $targetRef )
+                    {
+                        $objectInformation['relations'][] = $this->getReferenceID( $targetRef );
+                    }
+                    else
+                    {
+                        $this->writeMessage( 'Warning : No target defined for object relation' );
+                    }
+                }
+            }
+
             $refInfo = $this->createContentObject( $objectInformation );
 
             // $referenceList = $objectNode->getElementsByTagName( 'SetReference' );
@@ -432,6 +451,14 @@ class eZCreateContent extends eZXMLInstallerHandler
             if ( isset($objectInformation['ownerID']) && $objectInformation['ownerID'] != '' && $objectInformation['ownerID'] != 0 )
             {
                 $contentObject->setAttribute( 'owner_id',  $objectInformation['ownerID'] );
+            }
+
+            if( isset( $objectInformation['relations'] ) && is_array( $objectInformation['relations'] ) )
+            {
+                foreach( $objectInformation['relations'] as $toObjectID )
+                {
+                    $contentObject->addContentObjectRelation( $toObjectID );
+                }
             }
 
             $contentObjectVersion->store();

--- a/xmlinstallerhandler/ezcreaterole.php
+++ b/xmlinstallerhandler/ezcreaterole.php
@@ -117,7 +117,7 @@ class eZCreateRole extends eZXMLInstallerHandler
         }
         $this->addReference( $refArray );
     }
-    
+
     /**
      * Returns a valid limitation value to be saved in database
      *
@@ -130,6 +130,15 @@ class eZCreateRole extends eZXMLInstallerHandler
         $limitationValue = $this->getReferenceID( $limitationValue );
         switch( $limitationType )
         {
+            case 'Class':
+            case 'ParentClass':
+                $class = eZContentClass::fetchByIdentifier( $limitationValue );
+                if( $class )
+                {
+                    $limitationValue = $class->ID;
+                }
+                break;
+
             case 'Subtree':
                 //Subtree limitations need to store path_string instead of node_id
                 $val = (int) $limitationValue;
@@ -139,6 +148,7 @@ class eZCreateRole extends eZXMLInstallerHandler
                     $limitationValue = $node->attribute( 'path_string' );
                 }
    	            break;
+
             case 'SiteAccess':
                 //siteaccess name must be crc32'd
                 if( !is_int( $limitationValue ) )

--- a/xmlinstallerhandler/ezcreaterole.php
+++ b/xmlinstallerhandler/ezcreaterole.php
@@ -156,7 +156,18 @@ class eZCreateRole extends eZXMLInstallerHandler
 	               $limitationValue = eZSys::ezcrc32( $limitationValue );
                 }
                 break;
-         }
+
+            case 'Section':
+                if( !is_int( $limitationValue ) )
+                {
+                   $section = eZSection::fetchByIdentifier( $limitationValue );
+	               if( $section )
+	               {
+	                   $limitationValue = $section->attribute( 'id' );
+	               }
+                }
+                break;
+        }
 
         return $limitationValue;
     }

--- a/xmlinstallerhandler/ezcreaterole.php
+++ b/xmlinstallerhandler/ezcreaterole.php
@@ -132,10 +132,13 @@ class eZCreateRole extends eZXMLInstallerHandler
         {
             case 'Class':
             case 'ParentClass':
-                $class = eZContentClass::fetchByIdentifier( $limitationValue );
-                if( $class )
+                if( !is_int( $limitationValue ) )
                 {
-                    $limitationValue = $class->ID;
+                    $class = eZContentClass::fetchByIdentifier( $limitationValue );
+                    if( $class )
+                    {
+                        $limitationValue = $class->ID;
+                    }
                 }
                 break;
 

--- a/xmlinstallerhandler/ezcreatesection.php
+++ b/xmlinstallerhandler/ezcreatesection.php
@@ -36,10 +36,20 @@ class eZCreateSection extends eZXMLInstallerHandler
     {
         // ezcontentnavigationpart
         $sectionName    = $xmlNode->getAttribute( 'sectionName' );
+        $sectionIdentifier    = $xmlNode->getAttribute( 'sectionIdentifier' );
         $navigationPart = $xmlNode->getAttribute( 'navigationPart' );
         $referenceID    = $xmlNode->getAttribute( 'referenceID' );
 
-        $sectionID = $this->sectionIDbyName( $sectionName );
+        if( $sectionIdentifier )
+        {
+            $sectionID = eZSection::fetchByIdentifier( $sectionIdentifier );
+        }
+
+        if( !$sectionID )
+        {
+            $sectionID = $this->sectionIDbyName( $sectionName );
+        }
+
         if( $sectionID )
         {
             $this->writeMessage( "\tSection '$sectionName' already exists." , 'notice' );
@@ -48,6 +58,7 @@ class eZCreateSection extends eZXMLInstallerHandler
         {
             $section = new eZSection( array() );
             $section->setAttribute( 'name', $sectionName );
+            $section->setAttribute( 'identifier', $sectionIdentifier );
             $section->setAttribute( 'navigation_part_identifier', $navigationPart );
             $section->store();
             $sectionID = $section->attribute( 'id' );


### PR DESCRIPTION
Hi,
here are a few updates I made :
## CreateClass Handler
- Handling manual attribute placement instead of handling it only in new classes
- Attribute names are serialized later in process allowing update
- Class attributes are removed when replacing class
- Class attributes can now be set as information collectors
- Bug fix : when no class name is specified there is no change. (Previously first attribute name was used)
- Bug fix : when no urlAliasPattern was specified, it was replaced with a blank string
- Deleting an unnecessary and (IMHO) ill thought special case for ezboolean datatype default value
## CreateRole Handler
- Mapping class identifier to class ID for Class and ParentClass Limitations
- Mapping section identifier to section ID for Section Limitation
## CreateContent Handler
- Handling ezobjectrelationlist attributes content as a comma separated reference ids list
- Datatype content mapping falls back to fromString method instead of displaying error messages
- Handling node priorities either on an autoincrement basis or with fixed values
- Handling node sort array
- Allowing to set complete xml code instead of a single paragraph
## CreateSection handler
- new XML attribute `sectionIdentifier`
