### PR TITLE
CreateContent : inherit section

### DIFF
--- a/xmlinstallerhandler/ezcreatecontent.php
+++ b/xmlinstallerhandler/ezcreatecontent.php
@@ -602,7 +602,6 @@ class eZCreateContent extends eZXMLInstallerHandler
      */
     protected function getValidSectionID( $sectionID, $parentNodeID )
     {
-            //checking sectionID validity
         if( $sectionID )
         {
             $section = eZSection::fetch( $sectionID );
@@ -620,12 +619,17 @@ class eZCreateContent extends eZXMLInstallerHandler
             $parentNode = eZContentObjectTreeNode::fetch( $parentNodeID );
             if( $parentNode )
             {
-                return $parentNode->object()->attribute( 'section_id' );
+                $sectionID = $parentNode->object()->attribute( 'section_id' );
             }
         }
 
-            //unlikely case where parentNodeID is invalid too : standard section ID
-        return 1;
+            //you never know, final fallback to standard section
+        if( !$sectionID )
+        {
+            $sectionID = 1;
+        }
+
+        return $sectionID;
     }
 }
 

--- a/xmlinstallerhandler/ezcreatecontent.php
+++ b/xmlinstallerhandler/ezcreatecontent.php
@@ -92,7 +92,7 @@ class eZCreateContent extends eZXMLInstallerHandler
             $objectInformation['sort_order'] = $objectNode->hasAttribute( 'sort_order' ) ? $objectNode->getAttribute( 'sort_order' ) : 'asc';
 
                 //new objects should inherit their parent's section
-            if( !$objectInformation['sectionID'] )
+            if( !$objectInformation['sectionID'] || !( eZSection::fetch( $objectInformation['sectionID'] instanceof eZSection ) ) )
             {
                 $parentNode = eZContentObjectTreeNode::fetch( $parentNodeID );
                 if( $parentNode )

--- a/xmlinstallerhandler/ezcreatecontent.php
+++ b/xmlinstallerhandler/ezcreatecontent.php
@@ -91,6 +91,16 @@ class eZCreateContent extends eZXMLInstallerHandler
             $objectInformation['sort_field'] = $objectNode->hasAttribute( 'sort_field' ) ? $objectNode->getAttribute( 'sort_field' ) : 'path';
             $objectInformation['sort_order'] = $objectNode->hasAttribute( 'sort_order' ) ? $objectNode->getAttribute( 'sort_order' ) : 'asc';
 
+                //new objects should inherit their parent's section
+            if( !$objectInformation['sectionID'] )
+            {
+                $parentNode = eZContentObjectTreeNode::fetch( $parentNodeID );
+                if( $parentNode )
+                {
+                    $objectInformation['sectionID'] = $parentNode->object()->attribute( 'section_id' );
+                }
+            }
+
             switch( $priorityMode )
             {
                 case self::PRIORITY_MODE_AUTO:

--- a/xmlinstallerhandler/ezcreatesection.php
+++ b/xmlinstallerhandler/ezcreatesection.php
@@ -42,7 +42,11 @@ class eZCreateSection extends eZXMLInstallerHandler
 
         if( $sectionIdentifier )
         {
-            $sectionID = eZSection::fetchByIdentifier( $sectionIdentifier );
+            $section = eZSection::fetchByIdentifier( $sectionIdentifier );
+            if( $section )
+            {
+                $sectionID = $section->attribute( 'id' );
+            }
         }
 
         if( !$sectionID )


### PR DESCRIPTION
I guess it can be considered a bug fix : 
- when creating content, the new object section was set to standard by default no matter what section its parent was. It is now inherited from its parent if not manually set.

I also fixed a bug of mine in the CreateSection handler : 
- when setting a section identifier and that section already exists, the section object instead of the sectionID was stored in the reference array.
