### PR TITLE
fix createsection handler

### DIFF
--- a/settings/xmlinstaller.ini.append.php
+++ b/settings/xmlinstaller.ini.append.php
@@ -17,5 +17,6 @@ XMLInstallerHandler[]=ezcreatesection
 XMLInstallerHandler[]=ezcreateworkflow
 XMLInstallerHandler[]=ezsendmail
 XMLInstallerHandler[]=ezmodifycontent
+XMLInstallerHandler[]=ezmodifyfilecontent
 
 */?>

--- a/xmlinstallerhandler/ezcreatesection.php
+++ b/xmlinstallerhandler/ezcreatesection.php
@@ -49,7 +49,7 @@ class eZCreateSection extends eZXMLInstallerHandler
             }
         }
 
-        if( !$sectionID )
+        if( empty($sectionID) )
         {
             $sectionID = $this->sectionIDbyName( $sectionName );
         }

--- a/xmlinstallerhandler/ezcreatesection.php
+++ b/xmlinstallerhandler/ezcreatesection.php
@@ -42,7 +42,11 @@ class eZCreateSection extends eZXMLInstallerHandler
 
         if( $sectionIdentifier )
         {
-            $sectionID = eZSection::fetchByIdentifier( $sectionIdentifier );
+            $section = eZSection::fetchByIdentifier( $sectionIdentifier );
+            if ($section)
+            {
+                $sectionID = $section->attribute( 'id' );
+            }
         }
 
         if( !$sectionID )

--- a/xmlinstallerhandler/ezmodifyfilecontent.php
+++ b/xmlinstallerhandler/ezmodifyfilecontent.php
@@ -1,0 +1,54 @@
+<?php
+
+include_once('extension/ezxmlinstaller/classes/ezxmlinstallerhandler.php');
+
+class eZModifyFileContent extends eZXMLInstallerHandler
+{
+
+    function eZModifyFileContent( )
+    {
+    }
+
+    function execute( $xml )
+    {
+        $fileList = $xml->getElementsByTagName( 'File' );
+        foreach ( $fileList as $file )
+        {
+            $fileName = $file->getAttribute( 'name' );
+            $location = $file->getAttribute( 'location' );
+            $key      = $file->getAttribute( 'key' );
+            $value    = $this->getReferenceID( $file->getAttribute( 'value' ) );
+
+            $fileNamePath = $location . eZDir::separator( eZDir::SEPARATOR_LOCAL ) . $fileName;
+            if ( !file_exists( $fileNamePath ) )
+            {
+                $this->writeMessage("The file $fileNamePath does not exists", 'error');
+                continue;
+            }
+            elseif ( !is_writable($fileNamePath) )
+            {
+                $this->writeMessage("The file $fileNamePath is not writable", 'error');
+                continue;
+            }
+            
+            $str = file_get_contents( $fileNamePath );
+            $str = str_replace( $key, $value, $str);
+            
+            $fp = fopen( $fileNamePath, 'w' );
+            fwrite( $fp, $str );
+            fclose( $fp );
+            
+            $this->writeMessage("The file $fileNamePath has been updated");
+        }
+    }
+
+    static public function handlerInfo()
+    {
+        return array( 
+            'XMLName' => 'ModifyFileContent', 
+            'Info'    => 'modify a specific content in files' 
+        );
+    }
+}
+
+


### PR DESCRIPTION
This is a little fix for createSection handler which returned an eZSection object when the section already existed instead of the section id.
