### PR TITLE
Roles export with class identifier

### DIFF
--- a/classes/ezxmlinstallerhandler.php
+++ b/classes/ezxmlinstallerhandler.php
@@ -38,7 +38,7 @@ class eZXMLInstallerHandler
         $this->StepCounter    = $counter;
     }
 
-    function execute()
+    function execute( $par )
     {
     }
 

--- a/design/standard/templates/xmlexport/roles.tpl
+++ b/design/standard/templates/xmlexport/roles.tpl
@@ -9,7 +9,9 @@
             <Limitations>
             {foreach $policy.limitations as $limitation}
                 {foreach $limitation.values_as_array as $value}
-                    <{$limitation.identifier}>{$value}</{$limitation.identifier}>
+                    {def $class=fetch( 'content', 'class', hash( 'class_id', $value ) )}
+                    <{$limitation.identifier}>{$class.identifier|wash}</{$limitation.identifier}>
+                    {undef $class}
                 {/foreach}
             {/foreach}
             </Limitations>

--- a/xmlinstallerhandler/ezcreaterole.php
+++ b/xmlinstallerhandler/ezcreaterole.php
@@ -134,7 +134,7 @@ class eZCreateRole extends eZXMLInstallerHandler
             case 'ParentClass':
                 if( !is_int( $limitationValue ) )
                 {
-                    $class = eZContentClass::fetchByIdentifier( $limitationValue );
+                    $class = eZContentClass::fetchByIdentifier( trim( $limitationValue ) );
                     if( $class )
                     {
                         $limitationValue = $class->ID;


### PR DESCRIPTION
Template for roles export modified. It will export class identifier instead of class id in order to allow use of roles import on sites where class id is different.
